### PR TITLE
Call `create_or_set_default_schema` only once per connection

### DIFF
--- a/django_hana/base.py
+++ b/django_hana/base.py
@@ -194,13 +194,11 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         self.default_schema=self.settings_dict['NAME']
         # make it upper case
         self.default_schema=self.default_schema.upper()
-
+        self.create_or_set_default_schema()
 
     def _cursor(self):
         self.ensure_connection()
-        cursor = self.connection.cursor()
-        self.create_or_set_default_schema(cursor)
-        return cursor
+        return self.connection.cursor()
 
     def ensure_connection(self):
         if self.connection is None:
@@ -221,10 +219,11 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         return CursorDebugWrapper(cursor, self)
 
 
-    def create_or_set_default_schema(self,cursor):
+    def create_or_set_default_schema(self):
         """
             create if doesn't exist and then make it default
         """
+        cursor = self.cursor()
         cursor.execute("select (1) as a from schemas where schema_name='%s'" % self.default_schema)
         res=cursor.fetchone()
         if not res:


### PR DESCRIPTION
`create_or_set_default_schema` is being called once for every new cursor, which results in performing at least a `select (1) as a from schemas ...` query for every cursor. This practically doubles the number of queries performed, as very often cursors are only used for a single query, and there might be cases where a cursor is instantiated but never used, which will still perform the schema check query.

Moved the `create_or_set_default_schema` call into the `connect` method, so that it is called only once per connection instead of once per cursor.
